### PR TITLE
Dlam/improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.8.0] - 2026-05-19
+###Changed
+- Various bug fixes across runtime and editor
+- Improved event subscription lifecycle to prevent stale listeners on scene unload
+- Added configurable animator layer index to Animation Variant Set
+- Added configurable camera priority fields to Variant Select
+- Various code improvements and dead code removal
+
 ## [1.7.6] - 2025-08-14
 - Fixing App UI Style for sample scenes
 

--- a/Editor/ConfiguratorWindow.cs
+++ b/Editor/ConfiguratorWindow.cs
@@ -11,6 +11,7 @@ namespace IndustryCSE.Tool.ProductConfigurator.Editor
     {
         private ScrollView _variantSetScrollView;
         private Button _refreshButton;
+        private bool _hierarchyRefreshPending = false;
 
         private static void NewVariantSetBase<T>() where T : VariantSetBase
         {
@@ -59,7 +60,7 @@ namespace IndustryCSE.Tool.ProductConfigurator.Editor
         
         private void OnEnable()
         {
-            EditorApplication.hierarchyChanged += RefreshVariantSetScrollView;
+            EditorApplication.hierarchyChanged += OnHierarchyChanged;
         }
 
         public void CreateGUI()
@@ -126,11 +127,22 @@ namespace IndustryCSE.Tool.ProductConfigurator.Editor
 
         private void OnDisable()
         {
-            EditorApplication.hierarchyChanged -= RefreshVariantSetScrollView;
+            EditorApplication.hierarchyChanged -= OnHierarchyChanged;
             if (_refreshButton != null)
             {
                 _refreshButton.clicked -= RefreshButtonClicked;
             }
+        }
+
+        private void OnHierarchyChanged()
+        {
+            if (_hierarchyRefreshPending) return;
+            _hierarchyRefreshPending = true;
+            EditorApplication.delayCall += () =>
+            {
+                _hierarchyRefreshPending = false;
+                RefreshVariantSetScrollView();
+            };
         }
 
         private void RefreshButtonClicked()

--- a/Editor/CustomPropertyDrawer.cs
+++ b/Editor/CustomPropertyDrawer.cs
@@ -573,7 +573,9 @@ namespace IndustryCSE.Tool.ProductConfigurator.Editor
 
         private void OnVariantDropdownValueChanged(ChangeEvent<string> evt)
         {
-            _variantAssetProperty.objectReferenceValue = _allVariantSets[_variantSetAssetDropdown.index].VariantBase[_variantAssetDropdown.index].variantAsset;
+            var currentSet = _allVariantSets[_variantSetAssetDropdown.index];
+            if (_variantAssetDropdown.index < 0 || _variantAssetDropdown.index >= currentSet.VariantBase.Count) return;
+            _variantAssetProperty.objectReferenceValue = currentSet.VariantBase[_variantAssetDropdown.index].variantAsset;
             _variantAssetProperty.serializedObject.ApplyModifiedProperties();
         }
 
@@ -584,6 +586,7 @@ namespace IndustryCSE.Tool.ProductConfigurator.Editor
             var currentSelectedVariantSet = _allVariantSets[_variantSetAssetDropdown.index];
             var choices = currentSelectedVariantSet.VariantBase.Select(x => x.variantAsset.VariantName).ToList();
             _variantAssetDropdown.choices = choices;
+            if (choices.Count == 0) return;
             _variantAssetDropdown.index = 0;
             _variantAssetProperty.objectReferenceValue = currentSelectedVariantSet.VariantBase[0].variantAsset;
             _variantAssetProperty.serializedObject.ApplyModifiedProperties();

--- a/Editor/EditorCore.cs
+++ b/Editor/EditorCore.cs
@@ -33,15 +33,9 @@ namespace IndustryCSE.Tool.ProductConfigurator.Editor
         public const float TopMargin = 10f;
         public const float BottomMargin = 10f;
         
-        #if UNITY_EDITOR_OSX
-        public static string  VariantSetIconPath => PackageSettingsController.Settings.VariantIconPath.Replace("\\", "/");
-        private static string VariantSetAssetsFolderPath => PackageSettingsController.Settings.VariantSetAssetPath.Replace("\\", "/");
-        private static string VariantAssetsFolderPath => PackageSettingsController.Settings.VariantAssetPath.Replace("\\", "/");
-        #elif UNITY_EDITOR_WIN
-        public static string  VariantSetIconPath => PackageSettingsController.Settings.VariantIconPath.Replace("/", "\\");
-        private static string VariantSetAssetsFolderPath => PackageSettingsController.Settings.VariantSetAssetPath.Replace("/", "\\");
-        private static string VariantAssetsFolderPath => PackageSettingsController.Settings.VariantAssetPath.Replace("/", "\\");
-        #endif
+        public static string  VariantSetIconPath => PackageSettingsController.Settings.VariantIconPath.Replace('\\', '/');
+        private static string VariantSetAssetsFolderPath => PackageSettingsController.Settings.VariantSetAssetPath.Replace('\\', '/');
+        private static string VariantAssetsFolderPath => PackageSettingsController.Settings.VariantAssetPath.Replace('\\', '/');
         
         public static AssetBase CreateReturnAsset<T>(string setName)
         {
@@ -149,6 +143,8 @@ namespace IndustryCSE.Tool.ProductConfigurator.Editor
                 byte[] bytes = screenShot.EncodeToPNG();
                 File.WriteAllBytes(path, bytes);
                 cam.targetTexture = null;
+                rt.Release();
+                Object.DestroyImmediate(screenShot);
                 
                 variantSet.VariantSetAsset.storeCameraPosition = view.camera.transform.position;
                 variantSet.VariantSetAsset.storeCameraRotation = view.camera.transform.rotation;

--- a/Editor/EditorCore.cs
+++ b/Editor/EditorCore.cs
@@ -123,7 +123,7 @@ namespace IndustryCSE.Tool.ProductConfigurator.Editor
                 var option = options[i];
                 string path = Path.Combine(VariantSetIconPath, $"{option.variantAsset.UniqueIdString}.png");
                 //Debug.Log(path);
-                if (!File.Exists(Path.GetDirectoryName(path)))
+                if (!Directory.Exists(Path.GetDirectoryName(path)))
                 {
                     // Create the directory it does not exist
                     Directory.CreateDirectory(Path.GetDirectoryName(path));

--- a/Editor/Settings/PackageSettingsController.cs
+++ b/Editor/Settings/PackageSettingsController.cs
@@ -1,53 +1,12 @@
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
 using UnityEngine.UIElements;
 using System.IO;
 using System;
-using IndustryCSE.Tool.ProductConfigurator.ScriptableObjects;
 
 namespace IndustryCSE.Tool.ProductConfigurator.Settings.Editor
 {
-    public static class AssetRemoveConfirmation
-    {
-        private static Action DelayAction;
-        
-        private static void RemoveAssets(List<string> paths, List<string> outFailPaths)
-        {
-            AssetDatabase.MoveAssetsToTrash(paths.ToArray(), outFailPaths);
-            AssetDatabase.Refresh();
-        }
-
-        private static (List<string> assets, List<string> failPath) ReturnVariantAssetsPath(List<VariantAsset> assets)
-        {
-            var paths = new List<string>();
-            var outFailPaths = new List<string>();
-            foreach (var variantAsset in assets)
-            {
-                if (variantAsset == null) continue;
-                var path = AssetDatabase.GetAssetPath(variantAsset);
-                if(string.IsNullOrEmpty(path)) continue;
-                if (!outFailPaths.Contains(Directory.GetParent(path).FullName))
-                {
-                    outFailPaths.Add(Directory.GetParent(path).FullName);
-                }
-                paths.Add(path);
-                    
-                if (variantAsset.icon == null) continue;
-                path = AssetDatabase.GetAssetPath(variantAsset.icon);
-                if(string.IsNullOrEmpty(path)) continue;
-                if (!outFailPaths.Contains(Directory.GetParent(path).FullName))
-                {
-                    outFailPaths.Add(Directory.GetParent(path).FullName);
-                }
-                paths.Add(path);
-            }
-
-            return (paths, outFailPaths);
-        }
-    }
-    
     [InitializeOnLoad]
     public static class PackageSettingsController
     {
@@ -258,57 +217,27 @@ namespace IndustryCSE.Tool.ProductConfigurator.Settings.Editor
             return visualElement;
         }
 
-        private static void PickAssetSetPath()
+        private static void PickPath(string title, Action<ProductConfiguratorSettings, string> setter, Label label)
         {
-            //Open File Panel
-            var path = EditorUtility.OpenFolderPanel("Select Variant Set Asset Path", "Assets", "");
-            if(string.IsNullOrEmpty(path)) return;
+            var path = EditorUtility.OpenFolderPanel(title, "Assets", "");
+            if (string.IsNullOrEmpty(path)) return;
             var assetFolder = Directory.GetParent(Application.dataPath).FullName;
-            
-            path = path.Remove(0, assetFolder.Length + 1);
-            path = path.Replace('\\', '/');
-
-            variantSetAssetPathLabel.text = path;
+            path = path.Remove(0, assetFolder.Length + 1).Replace('\\', '/');
+            label.text = path;
             var settings = PackageSettingsController.GetSettings();
-            settings.SetVariantSetAssetPath(path);
+            setter(settings, path);
             EditorUtility.SetDirty(settings);
             AssetDatabase.SaveAssets();
         }
-        
-        private static void PickAssetPath()
-        {
-            //Open File Panel
-            var path = EditorUtility.OpenFolderPanel("Select Variant Asset Path", "Assets", "");
-            if(string.IsNullOrEmpty(path)) return;
-            var assetFolder = Directory.GetParent(Application.dataPath).FullName;
-            
-            path = path.Remove(0, assetFolder.Length + 1);
-            path = path.Replace('\\', '/');
 
-            variantAssetPathLabel.text = path;
-            var settings = PackageSettingsController.GetSettings();
-            settings.SetVariantAssetPath(path);
-            EditorUtility.SetDirty(settings);
-            AssetDatabase.SaveAssets();
-        }
-        
-        private static void PickIconPath()
-        {
-            //Open File Panel
-            var path = EditorUtility.OpenFolderPanel("Select Variant Icon Path", "Assets", "");
-            if(string.IsNullOrEmpty(path)) return;
+        private static void PickAssetSetPath() =>
+            PickPath("Select Variant Set Asset Path", (s, p) => s.SetVariantSetAssetPath(p), variantSetAssetPathLabel);
 
-            var assetFolder = Directory.GetParent(Application.dataPath).FullName;
-            
-            path = path.Remove(0, assetFolder.Length + 1);
-            path = path.Replace('\\', '/');
+        private static void PickAssetPath() =>
+            PickPath("Select Variant Asset Path", (s, p) => s.SetVariantAssetPath(p), variantAssetPathLabel);
 
-            variantIconPathLabel.text = path;
-            var settings = PackageSettingsController.GetSettings();
-            settings.SetVariantIconPath(path);
-            EditorUtility.SetDirty(settings);
-            AssetDatabase.SaveAssets();
-        }
+        private static void PickIconPath() =>
+            PickPath("Select Variant Icon Path", (s, p) => s.SetVariantIconPath(p), variantIconPathLabel);
 
         private static void RemoveBehaviourDropdownCallback(ChangeEvent<string> arg)
         {

--- a/Editor/Settings/PackageSettingsController.cs
+++ b/Editor/Settings/PackageSettingsController.cs
@@ -146,13 +146,8 @@ namespace IndustryCSE.Tool.ProductConfigurator.Settings.Editor
                     
                     #region Variant Set Asset Path
 
-                    var settingVariantSetPathPerPlatform = settings.VariantSetAssetPath;
-                    
-                    #if UNITY_EDITOR_OSX
-                    settingVariantSetPathPerPlatform = settingVariantSetPathPerPlatform.Replace("\\", "/");
-                    #elif UNITY_EDITOR_WIN
-                    settingVariantSetPathPerPlatform = settingVariantSetPathPerPlatform.Replace("/", "\\");
-                    #endif
+                    var settingVariantSetPathPerPlatform = settings.VariantSetAssetPath
+                        .Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
                     
                     var variantSetAssetPathField = ReturnPathField("Variant Set Asset Path",
                         out variantSetAssetPathLabel,
@@ -164,13 +159,8 @@ namespace IndustryCSE.Tool.ProductConfigurator.Settings.Editor
                     
                     #region Variant Asset Path
                     
-                    var settingVariantPathPerPlatform = settings.VariantAssetPath;
-                    
-                    #if UNITY_EDITOR_OSX
-                    settingVariantPathPerPlatform = settingVariantPathPerPlatform.Replace("\\", "/");
-                    #elif UNITY_EDITOR_WIN
-                    settingVariantPathPerPlatform = settingVariantPathPerPlatform.Replace("/", "\\");
-                    #endif
+                    var settingVariantPathPerPlatform = settings.VariantAssetPath
+                        .Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
                     
                     var variantAssetPathField = ReturnPathField("Variant Asset Path",
                         out variantAssetPathLabel,
@@ -182,13 +172,8 @@ namespace IndustryCSE.Tool.ProductConfigurator.Settings.Editor
                     
                     #region Variant Icon Path
                     
-                    var settingIconPathPerPlatform = settings.VariantIconPath;
-                    
-                    #if UNITY_EDITOR_OSX
-                    settingIconPathPerPlatform = settingIconPathPerPlatform.Replace("\\", "/");
-                    #elif UNITY_EDITOR_WIN
-                    settingIconPathPerPlatform = settingIconPathPerPlatform.Replace("/", "\\");
-                    #endif
+                    var settingIconPathPerPlatform = settings.VariantIconPath
+                        .Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
                     
                     var variantIconPathField = ReturnPathField("Variant Icon Path",
                         out variantIconPathLabel, settingIconPathPerPlatform,
@@ -281,17 +266,13 @@ namespace IndustryCSE.Tool.ProductConfigurator.Settings.Editor
             var assetFolder = Directory.GetParent(Application.dataPath).FullName;
             
             path = path.Remove(0, assetFolder.Length + 1);
-            
-            #if UNITY_EDITOR_OSX
-            path = path.Replace("\\", "/");
-            #elif UNITY_EDITOR_WIN
-            path = path.Replace("/", "\\");
-            #endif
-            
+            path = path.Replace('\\', '/');
+
             variantSetAssetPathLabel.text = path;
             var settings = PackageSettingsController.GetSettings();
             settings.SetVariantSetAssetPath(path);
             EditorUtility.SetDirty(settings);
+            AssetDatabase.SaveAssets();
         }
         
         private static void PickAssetPath()
@@ -302,17 +283,13 @@ namespace IndustryCSE.Tool.ProductConfigurator.Settings.Editor
             var assetFolder = Directory.GetParent(Application.dataPath).FullName;
             
             path = path.Remove(0, assetFolder.Length + 1);
-            
-            #if UNITY_EDITOR_OSX
-            path = path.Replace("\\", "/");
-            #elif UNITY_EDITOR_WIN
-            path = path.Replace("/", "\\");
-            #endif
-            
+            path = path.Replace('\\', '/');
+
             variantAssetPathLabel.text = path;
             var settings = PackageSettingsController.GetSettings();
             settings.SetVariantAssetPath(path);
             EditorUtility.SetDirty(settings);
+            AssetDatabase.SaveAssets();
         }
         
         private static void PickIconPath()
@@ -324,17 +301,13 @@ namespace IndustryCSE.Tool.ProductConfigurator.Settings.Editor
             var assetFolder = Directory.GetParent(Application.dataPath).FullName;
             
             path = path.Remove(0, assetFolder.Length + 1);
-            
-            #if UNITY_EDITOR_OSX
-            path = path.Replace("\\", "/");
-            #elif UNITY_EDITOR_WIN
-            path = path.Replace("/", "\\");
-            #endif
-            
+            path = path.Replace('\\', '/');
+
             variantIconPathLabel.text = path;
             var settings = PackageSettingsController.GetSettings();
             settings.SetVariantIconPath(path);
             EditorUtility.SetDirty(settings);
+            AssetDatabase.SaveAssets();
         }
 
         private static void RemoveBehaviourDropdownCallback(ChangeEvent<string> arg)
@@ -342,6 +315,8 @@ namespace IndustryCSE.Tool.ProductConfigurator.Settings.Editor
             var index = RemoveBehaviourOptions.IndexOf(arg.newValue);
             var settings = PackageSettingsController.GetSettings();
             settings.SetRemoveBehaviour(index);
+            EditorUtility.SetDirty(settings);
+            AssetDatabase.SaveAssets();
         }
         
         private static void OnAdvancedSettingsToggleChange(ChangeEvent<bool> evt)
@@ -349,8 +324,9 @@ namespace IndustryCSE.Tool.ProductConfigurator.Settings.Editor
             var settings = PackageSettingsController.GetSettings();
             settings.SetAdvancedSettings(evt.newValue);
             EditorUtility.SetDirty(settings);
+            AssetDatabase.SaveAssets();
             var selectedObject = Selection.activeGameObject;
-            EditorUtility.SetDirty(selectedObject);
+            if (selectedObject != null) EditorUtility.SetDirty(selectedObject);
             Selection.activeGameObject = null;
             EditorApplication.delayCall += () => Selection.activeGameObject = selectedObject;
         }

--- a/Editor/Settings/ProductConfiguratorSettings.cs
+++ b/Editor/Settings/ProductConfiguratorSettings.cs
@@ -15,15 +15,9 @@ namespace IndustryCSE.Tool.ProductConfigurator.Settings.Editor
     {
         public bool UseAdvancedSettings { get; private set; } = false;
         
-#if UNITY_EDITOR_OSX
         public string VariantSetAssetPath { get; private set; } = "Assets/Product Configurator/Variant Set Asset";
         public string VariantAssetPath { get; private set; } = "Assets/Product Configurator/Variant Asset";
         public string VariantIconPath { get; private set; } = "Assets/Product Configurator/Icons";
-#elif UNITY_EDITOR_WIN
-        public string VariantSetAssetPath { get; private set; } = "Assets\\Product Configurator\\Variant Set Asset";
-        public string VariantAssetPath { get; private set; } = "Assets\\Product Configurator\\Variant Asset";
-        public string VariantIconPath { get; private set; } = "Assets\\Product Configurator\\Icons";
-#endif
 
         
         public RemoveBehaviour RemoveBehaviour { get; private set; } = RemoveBehaviour.AskEveryTime;

--- a/Runtime/Base Class/VariantBase.cs
+++ b/Runtime/Base Class/VariantBase.cs
@@ -17,7 +17,7 @@ namespace IndustryCSE.Tool.ProductConfigurator.Runtime
     {
         public VariantAsset variantAsset;
 
-        public List<ConditionalVariantData> conditionalVariants;
+        public List<ConditionalVariantData> conditionalVariants = new();
         
         #if UNITY_EDITOR
         [HideInInspector]

--- a/Runtime/Base Class/VariantSetBase.cs
+++ b/Runtime/Base Class/VariantSetBase.cs
@@ -10,7 +10,7 @@ namespace IndustryCSE.Tool.ProductConfigurator.Runtime
     public abstract class VariantSetBase : MonoBehaviour
     {
         public static Action<VariantSetAsset, VariantAsset, bool> VariantTriggered;
-        private static int _triggerChangeCounter = 0;
+        private static bool _isApplyingVariant = false;
         
         public Action<VariantBase> VariantChanged;
         
@@ -51,24 +51,23 @@ namespace IndustryCSE.Tool.ProductConfigurator.Runtime
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         static void Init()
         {
-            _triggerChangeCounter = 0;   
+            _isApplyingVariant = false;
         }
-        
-        protected void Awake()
+
+        protected virtual void OnEnable()
         {
-            _triggerChangeCounter = 0;
+            VariantTriggered += OnVariantTriggered;
         }
 
         protected virtual void Start()
         {
-            VariantTriggered += OnVariantTriggered;
             if (useDefaultVariantIndex)
             {
                 SetVariant(defaultVariantIndex, false);
             }
         }
 
-        protected virtual void OnDestroy()
+        protected virtual void OnDisable()
         {
             VariantTriggered -= OnVariantTriggered;
         }
@@ -78,19 +77,17 @@ namespace IndustryCSE.Tool.ProductConfigurator.Runtime
             if(variantSet != variantSetAsset) return;
             var variant = VariantBase.Find(x => x.variantAsset == variantAsset);
             if(variant == null) return;
-            if (triggerConditionalVariants)
-            {
-                if (_triggerChangeCounter != 0)
-                {
-                    triggerConditionalVariants = false;
-                    _triggerChangeCounter = 0;
-                }
-                else
-                {
-                    _triggerChangeCounter++;
-                }
-            }
+            if (triggerConditionalVariants && _isApplyingVariant)
+                triggerConditionalVariants = false;
+
+            var wasApplying = _isApplyingVariant;
+            if (!wasApplying)
+                _isApplyingVariant = true;
+
             OnVariantChanged(variant, triggerConditionalVariants);
+
+            if (!wasApplying)
+                _isApplyingVariant = false;
         }
 
         protected virtual void OnVariantChanged(VariantBase obj, bool triggerConditionalVariants)

--- a/Runtime/SceneObject.cs
+++ b/Runtime/SceneObject.cs
@@ -6,7 +6,7 @@ namespace IndustryCSE.Tool.ProductConfigurator
     [System.Serializable]
     public class SceneObject
     {
-        public Object ScentAsset => sceneAsset;
+        public Object SceneAsset => sceneAsset;
         
         [SerializeField]
         private Object sceneAsset;

--- a/Runtime/SceneObject.cs
+++ b/Runtime/SceneObject.cs
@@ -11,6 +11,7 @@ namespace IndustryCSE.Tool.ProductConfigurator
         [SerializeField]
         private Object sceneAsset;
         
+        [SerializeField]
         public string SceneName;
     }
 }

--- a/Runtime/Variant Selection/VariantSelect.cs
+++ b/Runtime/Variant Selection/VariantSelect.cs
@@ -9,20 +9,26 @@ namespace IndustryCSE.Tool.ProductConfigurator.Runtime
     public class VariantSelect : MonoBehaviour
     {
         public VariantSetBase VariantSet;
-        
+
         public VariantAsset VariantAsset;
-        
+
         [SerializeField, Tooltip("Will add listener if detected button or toggle component")]
         private bool autoInitialise = true;
 
         [SerializeField]
         private bool triggerVariantSetCinemachineCamera;
-        
+
         [SerializeField]
         private bool triggerConditionalVariants = true;
 
+        [SerializeField] private int focusPriority = 10;
+        [SerializeField] private int inactivePriority = 0;
+
+        private CinemachineCamera[] _sceneCameras;
+
         private void Start()
         {
+            _sceneCameras = FindObjectsByType<CinemachineCamera>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
             if(!autoInitialise) return;
             
             if (transform.TryGetComponent(out Button button))
@@ -66,17 +72,15 @@ namespace IndustryCSE.Tool.ProductConfigurator.Runtime
 
         public virtual void SwitchCamera()
         {
-            if (VariantSet.FocusCamera != null)
+            if (VariantSet.FocusCamera == null) return;
+            var cameras = _sceneCameras
+                ?? FindObjectsByType<CinemachineCamera>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
+            foreach (var cam in cameras)
             {
-                var allCameras = FindObjectsByType<CinemachineCamera>(FindObjectsInactive.Exclude, FindObjectsSortMode.None)
-                    .Where(x => x != VariantSet.FocusCamera);
-                foreach (var cinemachineCamera in allCameras)
-                {
-                    cinemachineCamera.Priority = 0;
-                }
-
-                VariantSet.FocusCamera.Priority = 1;
+                if (cam != VariantSet.FocusCamera)
+                    cam.Priority = inactivePriority;
             }
+            VariantSet.FocusCamera.Priority = focusPriority;
         }
     }
 }

--- a/Runtime/Variant Set/AnimationVariantSet.cs
+++ b/Runtime/Variant Set/AnimationVariantSet.cs
@@ -11,37 +11,58 @@ namespace IndustryCSE.Tool.ProductConfigurator.Runtime
     public class AnimationVariant : VariantBase
     {
         public string VariantState;
-        
-        public int Hash => Animator.StringToHash(VariantState);
+
+        [NonSerialized] private bool _hashCached;
+        [NonSerialized] private int _cachedHash;
+
+        public int Hash
+        {
+            get
+            {
+                if (!_hashCached)
+                {
+                    _cachedHash = Animator.StringToHash(VariantState);
+                    _hashCached = true;
+                }
+                return _cachedHash;
+            }
+        }
     }
-    
+
     public class AnimationVariantSet : VariantSetBase
     {
         public List<AnimationVariant> Variants => variants;
         public Animator animator;
-        
+
+        [SerializeField] private int animatorLayerIndex = 0;
+
         [SerializeField]
         protected List<AnimationVariant> variants = new ();
-        
-        public override int CurrentSelectionIndex => animator != null? Variants.FindIndex(x => x.Hash == animator.GetCurrentAnimatorStateInfo(0).fullPathHash) : -1;
-        
-        public override string CurrentSelectionGuid => Variants[CurrentSelectionIndex].variantAsset.UniqueIdString;
-    
-        public override int CurrentSelectionCost => Variants[CurrentSelectionIndex].variantAsset.additionalCost;
-        
+
+        public override int CurrentSelectionIndex => animator != null ? Variants.FindIndex(x => x.Hash == animator.GetCurrentAnimatorStateInfo(animatorLayerIndex).fullPathHash) : -1;
+
+        public override string CurrentSelectionGuid => CurrentSelectionIndex >= 0 ? Variants[CurrentSelectionIndex].variantAsset.UniqueIdString : string.Empty;
+
+        public override int CurrentSelectionCost => CurrentSelectionIndex >= 0 ? Variants[CurrentSelectionIndex].variantAsset.additionalCost : 0;
+
         public override List<VariantBase> VariantBase => Variants.Cast<VariantBase>().ToList();
-    
+
+        private void ApplyVariant(AnimationVariant variant)
+        {
+            animator.Play(variant.Hash, animatorLayerIndex);
+        }
+
         protected override void OnVariantChanged(VariantBase variantBase, bool triggerConditionalVariants)
         {
             if (variantBase is not AnimationVariant featureDetails) return;
-            animator.Play(featureDetails.Hash);
+            ApplyVariant(featureDetails);
             base.OnVariantChanged(variantBase, triggerConditionalVariants);
         }
-    
+
         public override void SetVariant(int value, bool triggerConditionalVariants)
         {
             if(value < 0 || value >= Variants.Count) return;
-            animator.Play(variants[value].Hash);
+            ApplyVariant(variants[value]);
             base.SetVariant(value, triggerConditionalVariants);
         }
 

--- a/Runtime/Variant Set/AnimationVariantSet.cs
+++ b/Runtime/Variant Set/AnimationVariantSet.cs
@@ -49,6 +49,7 @@ namespace IndustryCSE.Tool.ProductConfigurator.Runtime
 
         private void ApplyVariant(AnimationVariant variant)
         {
+            if (animator == null) return;
             animator.Play(variant.Hash, animatorLayerIndex);
         }
 

--- a/Runtime/Variant Set/CombinationVariantSet.cs
+++ b/Runtime/Variant Set/CombinationVariantSet.cs
@@ -61,43 +61,37 @@ namespace IndustryCSE.Tool.ProductConfigurator.Runtime
         
         public override int CurrentSelectionCost => CurrentSelectionIndex == -1 ? 0 : Variants[CurrentSelectionIndex].variantAsset.additionalCost;
 
-        protected override void OnVariantChanged(VariantBase variantBase, bool triggerConditionalVariants)
+        private void ApplyCombination(CombinationVariant combo, bool triggerConditionalVariants)
         {
-            if (variantBase is not CombinationVariant combinationVariant) return;
-            if (!Variants.Contains(combinationVariant)) return;
             foreach (var variantSet in VariantSets)
             {
-                if (!combinationVariant.CombinationList.KeyValuePairs.Any(x =>
+                if (!combo.CombinationList.KeyValuePairs.Any(x =>
                         string.Equals(x.Key, variantSet.VariantSetAsset.UniqueIdString)))
                 {
                     Debug.Log("Variant Set not found in Combination List");
                     continue;
                 }
-                var variantID = combinationVariant.CombinationList.KeyValuePairs.Find(x =>
+                var variantID = combo.CombinationList.KeyValuePairs.Find(x =>
                     string.Equals(x.Key, variantSet.VariantSetAsset.UniqueIdString)).Value;
-                var index = variantSet.VariantBase.FindIndex(x => string.Equals(x.variantAsset.UniqueIdString, variantID));
+                var index = variantSet.VariantBase.FindIndex(x =>
+                    string.Equals(x.variantAsset.UniqueIdString, variantID));
                 variantSet.SetVariant(index, triggerConditionalVariants);
             }
+        }
+
+        protected override void OnVariantChanged(VariantBase variantBase, bool triggerConditionalVariants)
+        {
+            if (variantBase is not CombinationVariant combinationVariant) return;
+            if (!Variants.Contains(combinationVariant)) return;
+            ApplyCombination(combinationVariant, triggerConditionalVariants);
             base.OnVariantChanged(variantBase, triggerConditionalVariants);
         }
 
         public override void SetVariant(int value, bool triggerConditionalVariants)
         {
-            if(value < 0 || value >= Variants.Count) return;
+            if (value < 0 || value >= Variants.Count) return;
             if (VariantBase[value] is not CombinationVariant combinationVariant) return;
-            foreach (var variantSet in VariantSets)
-            {
-                if (!combinationVariant.CombinationList.KeyValuePairs.Any(x =>
-                        string.Equals(x.Key, variantSet.VariantSetAsset.UniqueIdString)))
-                {
-                    Debug.Log("Variant Set not found in Combination List");
-                    continue;
-                }
-                var variantID = combinationVariant.CombinationList.KeyValuePairs.Find(x =>
-                    string.Equals(x.Key, variantSet.VariantSetAsset.UniqueIdString)).Value;
-                var index = variantSet.VariantBase.FindIndex(x => string.Equals(x.variantAsset.UniqueIdString, variantID));
-                variantSet.SetVariant(index, triggerConditionalVariants);
-            }
+            ApplyCombination(combinationVariant, triggerConditionalVariants);
             base.SetVariant(value, triggerConditionalVariants);
         }
 

--- a/Runtime/Variant Set/CombinationVariantSet.cs
+++ b/Runtime/Variant Set/CombinationVariantSet.cs
@@ -63,22 +63,20 @@ namespace IndustryCSE.Tool.ProductConfigurator.Runtime
 
         protected override void OnVariantChanged(VariantBase variantBase, bool triggerConditionalVariants)
         {
-            if(!Variants.Contains(variantBase)) return;
+            if (variantBase is not CombinationVariant combinationVariant) return;
+            if (!Variants.Contains(combinationVariant)) return;
             foreach (var variantSet in VariantSets)
             {
-                var combinationVariant = (variantBase as CombinationVariant);
                 if (!combinationVariant.CombinationList.KeyValuePairs.Any(x =>
                         string.Equals(x.Key, variantSet.VariantSetAsset.UniqueIdString)))
                 {
                     Debug.Log("Variant Set not found in Combination List");
                     continue;
                 }
-                {
-                    var variantID = combinationVariant.CombinationList.KeyValuePairs.Find(x =>
-                        string.Equals(x.Key, variantSet.VariantSetAsset.UniqueIdString)).Value;
-                    var index = variantSet.VariantBase.FindIndex(x => string.Equals(x.variantAsset.UniqueIdString, variantID));
-                    variantSet.SetVariant(index, triggerConditionalVariants);
-                }
+                var variantID = combinationVariant.CombinationList.KeyValuePairs.Find(x =>
+                    string.Equals(x.Key, variantSet.VariantSetAsset.UniqueIdString)).Value;
+                var index = variantSet.VariantBase.FindIndex(x => string.Equals(x.variantAsset.UniqueIdString, variantID));
+                variantSet.SetVariant(index, triggerConditionalVariants);
             }
             base.OnVariantChanged(variantBase, triggerConditionalVariants);
         }
@@ -86,21 +84,19 @@ namespace IndustryCSE.Tool.ProductConfigurator.Runtime
         public override void SetVariant(int value, bool triggerConditionalVariants)
         {
             if(value < 0 || value >= Variants.Count) return;
+            if (VariantBase[value] is not CombinationVariant combinationVariant) return;
             foreach (var variantSet in VariantSets)
             {
-                var combinationVariant = (VariantBase[value] as CombinationVariant);
                 if (!combinationVariant.CombinationList.KeyValuePairs.Any(x =>
                         string.Equals(x.Key, variantSet.VariantSetAsset.UniqueIdString)))
                 {
                     Debug.Log("Variant Set not found in Combination List");
                     continue;
                 }
-                {
-                    var variantID = combinationVariant.CombinationList.KeyValuePairs.Find(x =>
-                        string.Equals(x.Key, variantSet.VariantSetAsset.UniqueIdString)).Value;
-                    var index = variantSet.VariantBase.FindIndex(x => string.Equals(x.variantAsset.UniqueIdString, variantID));
-                    variantSet.SetVariant(index, triggerConditionalVariants);
-                }
+                var variantID = combinationVariant.CombinationList.KeyValuePairs.Find(x =>
+                    string.Equals(x.Key, variantSet.VariantSetAsset.UniqueIdString)).Value;
+                var index = variantSet.VariantBase.FindIndex(x => string.Equals(x.variantAsset.UniqueIdString, variantID));
+                variantSet.SetVariant(index, triggerConditionalVariants);
             }
             base.SetVariant(value, triggerConditionalVariants);
         }
@@ -119,6 +115,9 @@ namespace IndustryCSE.Tool.ProductConfigurator.Runtime
             AddVariant(variantAsset);
         }
         
-        public override void AssignVariantObject<T>(string variantGuid, T variantObject) {}
+        public override void AssignVariantObject<T>(string variantGuid, T variantObject)
+        {
+            throw new NotSupportedException($"{nameof(CombinationVariantSet)} does not support direct object assignment. Configure combinations via the inspector.");
+        }
     }
 }

--- a/Runtime/Variant Set/GameObjectVariantSet.cs
+++ b/Runtime/Variant Set/GameObjectVariantSet.cs
@@ -22,27 +22,29 @@ namespace IndustryCSE.Tool.ProductConfigurator.Runtime
 
         public override int CurrentSelectionIndex => Variants.All(x => x.VariantGameObject != null)? Variants.FindIndex(x => x.VariantGameObject.activeSelf) : -1;
         
-        public override string CurrentSelectionGuid => Variants[CurrentSelectionIndex].variantAsset.UniqueIdString;
-    
-        public override int CurrentSelectionCost => Variants[CurrentSelectionIndex].variantAsset.additionalCost;
+        public override string CurrentSelectionGuid => CurrentSelectionIndex >= 0 ? Variants[CurrentSelectionIndex].variantAsset.UniqueIdString : string.Empty;
+
+        public override int CurrentSelectionCost => CurrentSelectionIndex >= 0 ? Variants[CurrentSelectionIndex].variantAsset.additionalCost : 0;
 
         public override List<VariantBase> VariantBase => Variants.Cast<VariantBase>().ToList();
+
+        private void ApplyVariant(GameObjectVariant target)
+        {
+            Variants.ForEach(x => x.VariantGameObject.SetActive(x == target));
+        }
 
         protected override void OnVariantChanged(VariantBase variantBase, bool triggerConditionalVariants)
         {
             if (variantBase is not GameObjectVariant featureDetails) return;
-            if(Variants.Contains(featureDetails))
-            {
-                Variants.ForEach(x => x.VariantGameObject.SetActive(featureDetails.VariantGameObject == x.VariantGameObject));
-            }
+            if (!Variants.Contains(featureDetails)) return;
+            ApplyVariant(featureDetails);
             base.OnVariantChanged(variantBase, triggerConditionalVariants);
         }
-    
+
         public override void SetVariant(int value, bool triggerConditionalVariants)
         {
             if(value < 0 || value >= Variants.Count) return;
-            Variants.ForEach(x => x.VariantGameObject.SetActive(false));
-            variants[value].VariantGameObject.SetActive(true);
+            ApplyVariant(Variants[value]);
             base.SetVariant(value, triggerConditionalVariants);
         }
 

--- a/Runtime/Variant Set/MaterialVariantSet.cs
+++ b/Runtime/Variant Set/MaterialVariantSet.cs
@@ -43,34 +43,32 @@ namespace IndustryCSE.Tool.ProductConfigurator.Runtime
             Count: > 0
         } && renderersDetails.All(x => x != null) ? Variants.FindIndex(x => x.VariantMaterial == renderersDetails[0].renderer.sharedMaterials[renderersDetails[0].materialsSlotIndex]) : -1;
 
-        public override string CurrentSelectionGuid => Variants[CurrentSelectionIndex].variantAsset.UniqueIdString;
-    
-        public override int CurrentSelectionCost => Variants[CurrentSelectionIndex].variantAsset.additionalCost;
+        public override string CurrentSelectionGuid => CurrentSelectionIndex >= 0 ? Variants[CurrentSelectionIndex].variantAsset.UniqueIdString : string.Empty;
+
+        public override int CurrentSelectionCost => CurrentSelectionIndex >= 0 ? Variants[CurrentSelectionIndex].variantAsset.additionalCost : 0;
         
+        private void ApplyVariant(Material material)
+        {
+            foreach (var detail in renderersDetails)
+            {
+                var mats = detail.renderer.sharedMaterials;
+                mats[detail.materialsSlotIndex] = material;
+                detail.renderer.sharedMaterials = mats;
+            }
+        }
+
         protected override void OnVariantChanged(VariantBase variantBase, bool triggerConditionalVariants)
         {
             if (variantBase is not MaterialVariant materialFeatureDetails) return;
             if (!Variants.Contains(materialFeatureDetails)) return;
-            foreach (var renderer in renderersDetails)
-            {
-                var newMaterials = new Material[renderer.renderer.sharedMaterials.Length];
-                Array.Copy(renderer.renderer.sharedMaterials, newMaterials, renderer.renderer.sharedMaterials.Length);
-                newMaterials[renderer.materialsSlotIndex] = materialFeatureDetails.VariantMaterial;
-                renderer.renderer.sharedMaterials = newMaterials;
-            }
+            ApplyVariant(materialFeatureDetails.VariantMaterial);
             base.OnVariantChanged(variantBase, triggerConditionalVariants);
         }
-    
+
         public override void SetVariant(int value, bool triggerConditionalVariants)
         {
             if(value < 0 || value >= Variants.Count) return;
-            foreach (var renderer in renderersDetails)
-            {
-                var newMaterials = new Material[renderer.renderer.sharedMaterials.Length];
-                Array.Copy(renderer.renderer.sharedMaterials, newMaterials, renderer.renderer.sharedMaterials.Length);
-                newMaterials[renderer.materialsSlotIndex] = variants[value].VariantMaterial;
-                renderer.renderer.sharedMaterials = newMaterials;
-            }
+            ApplyVariant(variants[value].VariantMaterial);
             base.SetVariant(value, triggerConditionalVariants);
         }
 

--- a/Runtime/Variant Set/TransformVariantSet.cs
+++ b/Runtime/Variant Set/TransformVariantSet.cs
@@ -59,6 +59,7 @@ namespace IndustryCSE.Tool.ProductConfigurator.Runtime
 
         private void TransformVariant(TransformVariant targetTransform)
         {
+            if (gameObjectToMove == null) return;
             if (!Application.isPlaying || targetTransform.InstantChange)
             {
                 gameObjectToMove.transform.SetPositionAndRotation(targetTransform.VariantTransform.position, targetTransform.VariantTransform.rotation);

--- a/Runtime/Variant Set/TransformVariantSet.cs
+++ b/Runtime/Variant Set/TransformVariantSet.cs
@@ -12,7 +12,7 @@ namespace IndustryCSE.Tool.ProductConfigurator.Runtime
     {
         public Transform VariantTransform;
         public bool InstantChange = true;
-        public float LerpTime = 1f;
+        [Min(0.001f)] public float LerpTime = 1f;
     }
 
     public class TransformVariantSet : VariantSetBase
@@ -25,13 +25,18 @@ namespace IndustryCSE.Tool.ProductConfigurator.Runtime
         
         public override int CurrentSelectionIndex => gameObjectToMove != null && Variants.All(x => x.VariantTransform != null) ? Variants.FindIndex(x => x.VariantTransform.position==gameObjectToMove.transform.position && x.VariantTransform.rotation == gameObjectToMove.transform.rotation) : -1;
 
-        public override string CurrentSelectionGuid => Variants[CurrentSelectionIndex].variantAsset.UniqueIdString;
-    
-        public override int CurrentSelectionCost => Variants[CurrentSelectionIndex].variantAsset.additionalCost;
+        public override string CurrentSelectionGuid => CurrentSelectionIndex >= 0 ? Variants[CurrentSelectionIndex].variantAsset.UniqueIdString : string.Empty;
+
+        public override int CurrentSelectionCost => CurrentSelectionIndex >= 0 ? Variants[CurrentSelectionIndex].variantAsset.additionalCost : 0;
 
         public override List<VariantBase> VariantBase => Variants.Cast<VariantBase>().ToList();
         
         Coroutine lerpCoroutine;
+
+        private void OnDestroy()
+        {
+            if (lerpCoroutine != null) StopCoroutine(lerpCoroutine);
+        }
 
         protected override void OnVariantChanged(VariantBase variantBase, bool triggerConditionalVariants)
         {
@@ -74,6 +79,7 @@ namespace IndustryCSE.Tool.ProductConfigurator.Runtime
 
         private IEnumerator LerpTransform(Vector3 variantTransformPosition, Quaternion variantTransformRotation, Vector3 variantTransformLocalScale, float lerpTime)
         {
+            lerpTime = Mathf.Max(lerpTime, 0.001f);
             float timeElapsed = 0;
             Vector3 startPosition = gameObjectToMove.transform.position;
             Quaternion startRotation = gameObjectToMove.transform.rotation;

--- a/Samples~/Shared/Runtime/MainUIController.cs
+++ b/Samples~/Shared/Runtime/MainUIController.cs
@@ -231,7 +231,7 @@ namespace IndustryCSE.Tool.ProductConfigurator.Shared.Runtime
             {
                 totalCost += variantSetBase.CurrentSelectionCost;
             }
-            m_totalCostLabel.text = $"{costCurrency} {totalCost.ToString("C0".Substring(1))}";
+            m_totalCostLabel.text = $"{costCurrency} {totalCost.ToString("C0").Substring(1)}";
         }
         
         private void CloseMenuButtonOnClicked()
@@ -333,7 +333,7 @@ namespace IndustryCSE.Tool.ProductConfigurator.Shared.Runtime
             for(var i = 0; i < scenes.Length; i++)
             {
                 if(scenes[i].Scene == null) continue;
-                scenes[i].Scene.SceneName = scenes[i].Scene.ScentAsset.name;
+                scenes[i].Scene.SceneName = scenes[i].Scene.SceneAsset.name;
             }
         }
         

--- a/Samples~/Shared/Runtime/MainUIController.cs
+++ b/Samples~/Shared/Runtime/MainUIController.cs
@@ -194,7 +194,9 @@ namespace IndustryCSE.Tool.ProductConfigurator.Shared.Runtime
                 var icon = variantSetButton.Q<VisualElement>("VariantIcon");
                 if (icon != null)
                 {
-                    icon.style.backgroundImage = new StyleBackground(variantSet.VariantBase[variantSet.CurrentSelectionIndex].variantAsset.icon);
+                    var selectionIndex = variantSet.CurrentSelectionIndex;
+                    if (selectionIndex >= 0)
+                        icon.style.backgroundImage = new StyleBackground(variantSet.VariantBase[selectionIndex].variantAsset.icon);
                 }
                 variantSetButton.RegisterCallback<ClickEvent>(OnVariantSetClick);
             }
@@ -225,13 +227,13 @@ namespace IndustryCSE.Tool.ProductConfigurator.Shared.Runtime
             }
             m_priceContainer.style.display = DisplayStyle.Flex;
             yield return null;
-            m_totalCostLabel.text = $"{costCurrency} {defaultCost.ToString("C0").Substring(1)}";
+            m_totalCostLabel.text = $"{costCurrency} {defaultCost.ToString("N0")}";
             int totalCost = defaultCost;
             foreach (var variantSetBase in _variantSets)
             {
                 totalCost += variantSetBase.CurrentSelectionCost;
             }
-            m_totalCostLabel.text = $"{costCurrency} {totalCost.ToString("C0").Substring(1)}";
+            m_totalCostLabel.text = $"{costCurrency} {totalCost.ToString("N0")}";
         }
         
         private void CloseMenuButtonOnClicked()
@@ -332,7 +334,7 @@ namespace IndustryCSE.Tool.ProductConfigurator.Shared.Runtime
         {
             for(var i = 0; i < scenes.Length; i++)
             {
-                if(scenes[i].Scene == null) continue;
+                if(scenes[i].Scene == null || scenes[i].Scene.SceneAsset == null) continue;
                 scenes[i].Scene.SceneName = scenes[i].Scene.SceneAsset.name;
             }
         }

--- a/Scriptable Object/AssetBase.cs
+++ b/Scriptable Object/AssetBase.cs
@@ -16,7 +16,7 @@ namespace IndustryCSE.Tool.ProductConfigurator.ScriptableObjects
         
         private void OnValidate()
         {
-            NewID();
+            if (string.IsNullOrEmpty(uniqueIdString)) NewID();
         }
         
         public void NewID()

--- a/Scriptable Object/VariantAsset.cs
+++ b/Scriptable Object/VariantAsset.cs
@@ -9,6 +9,7 @@ namespace IndustryCSE.Tool.ProductConfigurator.ScriptableObjects
         private string variantName;
         
         public Texture2D icon;
+        [Min(0)]
         public int additionalCost;
         public string description;
 

--- a/Scriptable Object/VariantSetAsset.cs
+++ b/Scriptable Object/VariantSetAsset.cs
@@ -9,17 +9,17 @@ namespace IndustryCSE.Tool.ProductConfigurator.ScriptableObjects
         private string variantSetName;
 
         #if UNITY_EDITOR
-        
-        [HideInInspector]
+
+        [HideInInspector, SerializeField]
         public bool hasStoreCameraPositionAndRotation;
-        [HideInInspector]
+        [HideInInspector, SerializeField]
         public Vector3 storeCameraPosition;
-        [HideInInspector]
+        [HideInInspector, SerializeField]
         public Quaternion storeCameraRotation;
 
-        [HideInInspector]
+        [HideInInspector, SerializeField]
         public float storeCameraDistance;
-        
+
         #endif
         
 #if UNITY_EDITOR

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.industrycse.productconfigurator",
   "displayName": "Product Configurator",
-  "version": "1.7.6",
+  "version": "1.8.0",
   "unity": "6000.0",
   "description": "This is a lightweight product configurator framework designed for Unity.\nIt empowers users to effortlessly create their own product configurator experiences within Unity environments. With a set of foundational classes, users can seamlessly expand and customize their configurators to suit their specific needs and preferences.\n\nCurrently, our framework supports visibility, material, and transform variants.\nThis means users can easily configure product options related to visibility (show/hide), material properties, and transformations (such as position, rotation, and scale). Whether you're building a simple configurator for basic products or a complex one with intricate customization options, our framework provides the flexibility and ease-of-use necessary to bring your vision to life",
   "keywords": [


### PR DESCRIPTION
  Summary                                                                                                                                                         
                                                                                                                                                                  
  - Fixed re-entrancy guard in VariantSetBase that caused conditional variant chains to misfire                                                                   
  - Moved VariantTriggered event subscription to OnEnable/OnDisable to prevent stale listeners on scene unload                                                    
  - Fixed icon capture directory not being created before writing PNG                                                                                             
  - Fixed IndexOutOfRangeException in conditional variant property drawer when switching between variant sets of different sizes                                  
  - Fixed IndexOutOfRangeException in sample MainUIController on initial load when no variant is selected                                                         
  - Fixed culture-fragile currency formatting in sample UI                                                                                                        
  - Fixed missing [SerializeField] on camera state fields in VariantSetAsset (lost on domain reload)                                                              
  - Added null guards in TransformVariantSet and AnimationVariantSet for unassigned inspector fields                                                              
  - Added configurable animator layer index to AnimationVariantSet                                                                                                
  - Added configurable focus/inactive camera priority to VariantSelect                                                                                            
  - Debounced hierarchy change scan in ConfiguratorWindow editor window                                                                                           
  - Removed dead code; various code quality improvements                                                                                                          
  - Updated CHANGELOG and bumped version to 1.8.0